### PR TITLE
Added patch to fix integer overflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tessera
 Title: Accurate Tiling of Spatial Single-Cell Data
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: c(
     person("Ilya", "Korsunsky", , "ilya.korsunsky@gmail.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0003-4848-3948")),

--- a/R/utils_aggregation.R
+++ b/R/utils_aggregation.R
@@ -76,7 +76,7 @@ init_scores = function(aggs, agg_mode, ...) {
         
         
         # GMM to decide which distances are good or bad 
-        d = sqrt(rowSums((aggs$pcs[aggs$edges$from, ] - aggs$pcs[aggs$edges$to, ])^2))
+        d = sqrt(rowSums((aggs$pcs[aggs$edges$from,,drop=FALSE] - aggs$pcs[aggs$edges$to,,drop=FALSE])^2))
         mres = mclust::Mclust(d, G=2)
         ord = order(mres$parameters$mean)
         stopifnot(mres$parameters$mean[ord[1]] < mres$parameters$mean[ord[2]])
@@ -97,7 +97,7 @@ init_scores = function(aggs, agg_mode, ...) {
         a0 = aggs$meta_data$npts[aggs$edges$from]
         a1 = aggs$meta_data$npts[aggs$edges$to]
         atot = a0 + a1
-        aggs$pcs_merged = sweep(aggs$pcs[aggs$edges$from, ], 1, a0, '*') + sweep(aggs$pcs[aggs$edges$to, ], 1, a1, '*')
+        aggs$pcs_merged = sweep(aggs$pcs[aggs$edges$from,,drop=FALSE], 1, a0, '*') + sweep(aggs$pcs[aggs$edges$to,,drop=FALSE], 1, a1, '*')
         aggs$pcs_merged = sweep(aggs$pcs_merged, 1, atot, '/')
         aggs$edges$perimeter_merge = aggs$meta_data$perimeter[aggs$edges$from] + aggs$meta_data$perimeter[aggs$edges$to] - 2 * aggs$edges$edge_length
         # aggs$edges$nedges_internal_merge = 1
@@ -133,7 +133,7 @@ init_scores = function(aggs, agg_mode, ...) {
         atot = a0 + a1
 
         # GMM to decide which distances are good or bad 
-        d = sqrt(rowSums((aggs$pcs[aggs$edges$from, ] - aggs$pcs[aggs$edges$to, ])^2))
+        d = sqrt(rowSums((aggs$pcs[aggs$edges$from,,drop=FALSE] - aggs$pcs[aggs$edges$to,,drop=FALSE])^2))
         mres = mclust::Mclust(d, G=2)
         ord = order(mres$parameters$mean)
         stopifnot(mres$parameters$mean[ord[1]] < mres$parameters$mean[ord[2]])
@@ -446,10 +446,10 @@ merge_aggs = function(
     
     e_keep = which(!is.infinite(aggs$edges$dscore))
     aggs$edges = aggs$edges[e_keep, ]
-    aggs$pcs_merged = aggs$pcs_merged[e_keep, ]
+    aggs$pcs_merged = aggs$pcs_merged[e_keep,,drop=FALSE]
     aggs$edges$from = aggmap[aggs$edges$from]
     aggs$edges$to = aggmap[aggs$edges$to]
-    aggs$pcs = aggs$pcs[aggs_keep, ]
+    aggs$pcs = aggs$pcs[aggs_keep,,drop=FALSE]
     
     return(aggs)
 

--- a/R/utils_analysis.R
+++ b/R/utils_analysis.R
@@ -36,7 +36,7 @@ RunUMAPCustom = function(
 
     embeddings = Seurat::Embeddings(obj, reduction)
     if (!is.null(dims)) {
-        embeddings = embeddings[,dims]
+        embeddings = embeddings[,dims,drop=FALSE]
     }
 
     if (fgraph_only) {
@@ -182,9 +182,9 @@ MakeSubClusterObj = function(
     # counts = obj[["RNA"]]$counts[,subset_idx]
     # colnames(counts) = NULL
     obj_sub = Seurat::CreateSeuratObject(
-        counts = obj[[assay]]$counts[,subset_idx],
+        counts = obj[[assay]]$counts[,subset_idx,drop=FALSE],
         # counts = counts,
-        meta.data = obj@meta.data[subset_idx, meta.vars.include]
+        meta.data = obj@meta.data[subset_idx, meta.vars.include, drop=FALSE]
     )
 
     if (is.null(use.existing.embeddings)) {
@@ -198,7 +198,7 @@ MakeSubClusterObj = function(
         reduction = "pca"
     } else {
         obj_sub[[use.existing.embeddings]] <- Seurat::CreateDimReducObject(
-            embeddings = Seurat::Embeddings(obj, use.existing.embeddings)[subset_idx,],
+            embeddings = Seurat::Embeddings(obj, use.existing.embeddings)[subset_idx,,drop=FALSE],
             loadings = Seurat::Loadings(obj, use.existing.embeddings),
             key = use.existing.embeddings
         )
@@ -270,7 +270,7 @@ MakeTileSubClusterObj = function(
     subset_idx = which(tile_obj@meta.data[[clusters.name]] == cluster)
     meta.vars.include = unique(c(meta.vars.include, harmony.group.by.vars))
     tile_obj_sub = Seurat::CreateSeuratObject(
-        counts = tile_obj[[tile_assay]]$counts[,subset_idx],
+        counts = tile_obj[[tile_assay]]$counts[,subset_idx,drop=FALSE],
         meta.data = tile_obj@meta.data[subset_idx, meta.vars.include, drop=FALSE]
     )
     
@@ -283,7 +283,7 @@ MakeTileSubClusterObj = function(
         meta.vars.include = unique(c(meta.vars.include, harmony.group.by.vars, 'tile_id'))
         
         cell_obj_sub = Seurat::CreateSeuratObject(
-            counts = cell_obj[[cell_assay]]$counts[,cell_subset_idx],
+            counts = cell_obj[[cell_assay]]$counts[,cell_subset_idx,drop=FALSE],
             meta.data = cell_obj@meta.data[cell_subset_idx, meta.vars.include, drop=FALSE]
         )
         
@@ -309,7 +309,7 @@ MakeTileSubClusterObj = function(
         embeddings = Seurat::Embeddings(cell_obj_sub, reduction)
         loadings = Seurat::Loadings(cell_obj_sub, reduction)
         if (!all(smooth_emb == 0)) {
-            adj = Seurat::as.sparse(cell_obj[[graph.name.cells]])[cell_subset_idx,cell_subset_idx]
+            adj = Seurat::as.sparse(cell_obj[[graph.name.cells]])[cell_subset_idx,cell_subset_idx,drop=FALSE]
             diag(adj) = 1
             adj = adj / Matrix::colSums(adj)  # normalize
 
@@ -336,13 +336,13 @@ MakeTileSubClusterObj = function(
         tile_obj_sub[[reduction]] <- Seurat::CreateDimReducObject(
             embeddings = aggregate_embeddings(
                 embeddings, droplevels(cell_obj_sub$tile_id)
-            )[colnames(tile_obj_sub),],
+            )[colnames(tile_obj_sub),,drop=FALSE],
             loadings = loadings,
             key = reduction
         )
     } else {
         tile_obj_sub[[use.existing.embeddings]] <- Seurat::CreateDimReducObject(
-            embeddings = Seurat::Embeddings(tile_obj, use.existing.embeddings)[subset_idx,],
+            embeddings = Seurat::Embeddings(tile_obj, use.existing.embeddings)[subset_idx,,drop=FALSE],
             loadings = Seurat::Loadings(tile_obj, use.existing.embeddings),
             key = use.existing.embeddings
         )

--- a/R/utils_dmt.R
+++ b/R/utils_dmt.R
@@ -52,15 +52,15 @@ dmt_get_separatrices = function(dmt) {
 #' @export
 dmt_set_f = function(dmt, field, f_norm = FALSE) {
     if (f_norm) {
-        dmt$pts$f = norm(field$pts_svd[, 5:6], type = "F")
-        dmt$tris$f = norm(field$tris_svd[, 5:6], type = "F")
-        dmt$edges$f_prim = norm(field$edges_pts_svd[, 5:6], type = "F")
-        dmt$edges$f_dual = norm(field$edges_tris_svd[, 5:6], type = "F")
+        dmt$pts$f = norm(field$pts_svd[, 5:6, drop=FALSE], type = "F")
+        dmt$tris$f = norm(field$tris_svd[, 5:6, drop=FALSE], type = "F")
+        dmt$edges$f_prim = norm(field$edges_pts_svd[, 5:6, drop=FALSE], type = "F")
+        dmt$edges$f_dual = norm(field$edges_tris_svd[, 5:6, drop=FALSE], type = "F")
     } else {
-        dmt$pts$f = rowSums(field$pts_svd[, 5:6])
-        dmt$tris$f = rowSums(field$tris_svd[, 5:6])
-        dmt$edges$f_prim = rowSums(field$edges_pts_svd[, 5:6])
-        dmt$edges$f_dual = rowSums(field$edges_tris_svd[, 5:6])
+        dmt$pts$f = rowSums(field$pts_svd[, 5:6, drop=FALSE])
+        dmt$tris$f = rowSums(field$tris_svd[, 5:6, drop=FALSE])
+        dmt$edges$f_prim = rowSums(field$edges_pts_svd[, 5:6, drop=FALSE])
+        dmt$edges$f_dual = rowSums(field$edges_tris_svd[, 5:6, drop=FALSE])
     }
     return(dmt)
 }

--- a/R/utils_dmt.R
+++ b/R/utils_dmt.R
@@ -333,11 +333,12 @@ dmt_init_tiles = function(dmt) {
 #' @export
 dmt_assign_tiles = function(dmt) {
     e = setdiff(seq_len(nrow(dmt$edges)), dmt$e_sep)
-    # igraph::components(igraph::from_edgelist()$fun(as.matrix(dmt$edges)[e, c("from_pt", "to_pt")], FALSE))$membership
-    g = Matrix::sparseMatrix(i = dmt$edges$from_pt[e], j = dmt$edges$to_pt[e], x = 1, dims = c(nrow(dmt$pts), nrow(dmt$pts)))
-    g = igraph::from_adjacency()$fun(g, 'undirected')
+    n_pts = nrow(dmt$pts)
+    el = cbind(dmt$edges$from_pt[e], dmt$edges$to_pt[e])
+    g = igraph::make_empty_graph(n = n_pts, directed = FALSE)
+    g = igraph::add_edges(g, as.vector(t(el)))
     dmt$pts$agg_id = igraph::components(g)$membership
     dmt$edges$agg_from = dmt$pts$agg_id[dmt$edges$from_pt]
-    dmt$edges$agg_to = dmt$pts$agg_id[dmt$edges$to_pt]    
+    dmt$edges$agg_to = dmt$pts$agg_id[dmt$edges$to_pt]
     return(dmt)
 }

--- a/R/utils_pca.R
+++ b/R/utils_pca.R
@@ -70,7 +70,7 @@ scale_data = function (A, margin = 1, thresh = 10) {
 do_pca = function(counts, npcs) {
     logcpx = normalize_data(counts)
     Z = scale_data(logcpx)
-    Z = Z[which(is.na(Matrix::rowSums(Z)) == 0), ]
+    Z = Z[which(is.na(Matrix::rowSums(Z)) == 0),,drop=FALSE]
     pres = RSpectra::svds(Z, npcs)
     V = sweep(pres$v, 2, pres$d, '*')
     colnames(V) = paste0('PC', 1:npcs)

--- a/R/utils_ui.R
+++ b/R/utils_ui.R
@@ -544,7 +544,7 @@ GetTiles.default = function(
 
         ## STEP 0: PREPARE DATA STRUCTURES
         if (verbose) message('STEP 0: PREPARE DATA STRUCTURES')
-        dmt = init_data(X[idx], Y[idx], counts[,idx], meta_data[idx,], meta_vars_include)
+        dmt = init_data(X[idx], Y[idx], counts[,idx,drop=FALSE], meta_data[idx,,drop=FALSE], meta_vars_include)
         dmt = prune_graph(dmt, thresh_quantile = prune_thresh_quantile,
                         mincells = prune_min_cells, thresh = prune_thresh)
         dmt = add_exterior_triangles(dmt)
@@ -554,7 +554,7 @@ GetTiles.default = function(
         } else {
             dmt$udv_cells = list(
                 loadings = loadings,
-                embeddings = embeddings[idx,][as.integer(dmt$pts$ORIG_ID),]
+                embeddings = embeddings[idx,,drop=FALSE][as.integer(dmt$pts$ORIG_ID),,drop=FALSE]
             )
         }
         if (any(smooth_emb > 0)) {


### PR DESCRIPTION
Resolving this issue: "dmt_assign_tiles fails with integer overflow on samples with >46K cells (Matrix >= 1.7)"

Applied patch proposed by wmoldham here: https://github.com/korsunskylab/tessera/issues/24